### PR TITLE
Refactoring for better testability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ function parseHundreds(hundreds: number): string {
 }
 
 function extractDecimals(nr: number): number {
-  return +nr.toFixed(2) * 100 - Math.trunc(nr) * 100;
+  return Math.trunc(+nr.toFixed(2) * 100) - Math.trunc(Math.trunc(nr) * 100);
 }
 
 function parseDecimals(decimals: number): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,11 @@ const TENTHS_LESS_THAN_HUNDRED = [
 ];
 
 export function generateWords(nr: number, words: string[] = []): string {
+  let remainder = 0;
+  let quotient: number;
+  let integer: number;
+  let decimals: number;
+
   // If NaN stop and return 'NaN'
   if (isNaN(nr)) {
     return 'NaN';
@@ -62,11 +67,6 @@ export function generateWords(nr: number, words: string[] = []): string {
     words.push('minus');
     nr = Math.abs(nr);
   }
-
-  let remainder = 0;
-  let quotient: number;
-  let integer: number;
-  let decimals: number;
 
   switch (true) {
     case (nr < 20):


### PR DESCRIPTION
This is the upmost I could do at this time.
I still have some issues with how recursion is triggered inside` match()` and `parseDecimals()`.
I have removed `replace(/,$/, '');` from `replace(/,$/, '');` just because it doesn't has the desired effect. To properly format numbers like `100,00` you should apply a reducer on the number and not the generated output (which is a string controlled by the recursive function).
The aim of how `generateWords()` was refactored was to make it easier to read top to bottom and also to improve testability. I think I added 10 more lines of code (overall) but this can eventually be reduced.